### PR TITLE
Add managed XTTS voice deletion

### DIFF
--- a/tests/test_voice_management.py
+++ b/tests/test_voice_management.py
@@ -1,0 +1,34 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from xtts_api_server.voice_management import delete_flat_voice, normalize_voice_id
+
+
+class VoiceManagementTest(unittest.TestCase):
+    def test_deletes_flat_uploaded_voice(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            voice = Path(temp_dir) / "sample.wav"
+            voice.write_bytes(b"wav")
+
+            removed = delete_flat_voice(temp_dir, "sample")
+
+            self.assertEqual(removed, voice)
+            self.assertFalse(voice.exists())
+
+    def test_does_not_delete_multi_sample_directory(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            voice_dir = Path(temp_dir) / "sample"
+            voice_dir.mkdir()
+            (voice_dir / "one.wav").write_bytes(b"wav")
+
+            self.assertIsNone(delete_flat_voice(temp_dir, "sample"))
+            self.assertTrue(voice_dir.exists())
+
+    def test_rejects_path_traversal(self):
+        with self.assertRaises(ValueError):
+            normalize_voice_id("../sample")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/xtts_api_server/server.py
+++ b/xtts_api_server/server.py
@@ -1,5 +1,5 @@
 from TTS.api import TTS
-from fastapi import BackgroundTasks, FastAPI, HTTPException, Request, Query, File, UploadFile
+from fastapi import BackgroundTasks, FastAPI, HTTPException, Request, Query, File, Form, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse,StreamingResponse
 
@@ -18,6 +18,7 @@ from uuid import uuid4
 from xtts_api_server.tts_funcs import TTSWrapper,supported_languages,InvalidSettingsError
 from xtts_api_server.RealtimeTTS import TextToAudioStream, CoquiEngine
 from xtts_api_server.modeldownloader import check_stream2sentence_version,install_deepspeed_based_on_python_version
+from xtts_api_server.voice_management import delete_flat_voice, flat_voice_path, normalize_voice_id
 
 # Default Folders , you can change them via API
 DEVICE = os.getenv('DEVICE',"cuda")
@@ -146,6 +147,20 @@ def get_speakers():
     speakers = XTTS.get_speakers()
     return speakers
 
+@app.get("/speakers_list_extended")
+def get_speakers_extended():
+    speakers = []
+    for speaker in XTTS._get_speakers():
+        voice_id = speaker['speaker_name']
+        can_delete = flat_voice_path(XTTS.speaker_folder, voice_id).is_file()
+        speakers.append({
+            **speaker,
+            "voice_id": voice_id,
+            "can_delete": can_delete,
+            "source": "uploaded_sample" if can_delete else "managed_directory",
+        })
+    return {"speakers": speakers, "count": len(speakers)}
+
 @app.get("/speakers")
 def get_speakers():
     speakers = XTTS.get_speakers_special()
@@ -204,14 +219,53 @@ def set_speaker_folder(speaker_req: SpeakerFolderRequest):
         raise HTTPException(status_code=400, detail=str(e))
 
 @app.post("/upload_sample")
-async def upload_sample(wavFile: UploadFile = File(...)):
+async def upload_sample(
+    wavFile: UploadFile = File(...),
+    force: bool = Form(default=False),
+):
+    del force  # XTTS has historically replaced same-name flat samples.
+    if not wavFile.filename or not wavFile.filename.lower().endswith('.wav'):
+        raise HTTPException(status_code=400, detail="Only .wav files are supported")
+    try:
+        voice_id = normalize_voice_id(wavFile.filename)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    UPLOAD_DIR = XTTS.speaker_folder
-    os.makedirs(UPLOAD_DIR, exist_ok=True)
-    file_path = os.path.join(UPLOAD_DIR, wavFile.filename)
-    with open(file_path, "wb") as file_object:
-        file_object.write(await wavFile.read())
-    return {"filename": wavFile.filename}
+    upload_dir = Path(XTTS.speaker_folder)
+    upload_dir.mkdir(parents=True, exist_ok=True)
+    file_path = flat_voice_path(upload_dir, voice_id)
+    content = await wavFile.read()
+    if not content:
+        raise HTTPException(status_code=400, detail="Uploaded WAV is empty")
+
+    replaced = file_path.exists()
+    temp_path = upload_dir / f".upload-{uuid4().hex}.wav"
+    try:
+        temp_path.write_bytes(content)
+        os.replace(temp_path, file_path)
+    finally:
+        if temp_path.exists():
+            temp_path.unlink()
+    XTTS.latents_cache.pop(voice_id, None)
+    return {"filename": file_path.name, "voice_id": voice_id, "replaced": replaced}
+
+
+@app.delete("/voices/{voice_id}")
+def delete_voice(voice_id: str):
+    try:
+        normalized = normalize_voice_id(voice_id)
+        removed = delete_flat_voice(XTTS.speaker_folder, normalized)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if removed is None:
+        raise HTTPException(status_code=404, detail=f"Uploaded voice '{normalized}' was not found")
+    XTTS.latents_cache.pop(normalized, None)
+    return {
+        "status": "deleted",
+        "voice_id": normalized,
+        "removed": [removed.name],
+        "cache_invalidated": True,
+    }
 
 
 @app.post("/switch_model")

--- a/xtts_api_server/voice_management.py
+++ b/xtts_api_server/voice_management.py
@@ -1,0 +1,26 @@
+import re
+from pathlib import Path
+
+
+VOICE_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
+
+
+def normalize_voice_id(value: str) -> str:
+    voice_id = str(value or "").strip()
+    if voice_id.lower().endswith(".wav"):
+        voice_id = voice_id[:-4]
+    if "/" in voice_id or "\\" in voice_id or not VOICE_ID_PATTERN.fullmatch(voice_id):
+        raise ValueError("Voice ID must use only letters, numbers, dot, dash, or underscore.")
+    return voice_id
+
+
+def flat_voice_path(speaker_folder: str | Path, voice_id: str) -> Path:
+    return Path(speaker_folder) / f"{normalize_voice_id(voice_id)}.wav"
+
+
+def delete_flat_voice(speaker_folder: str | Path, voice_id: str) -> Path | None:
+    path = flat_voice_path(speaker_folder, voice_id)
+    if not path.is_file():
+        return None
+    path.unlink()
+    return path


### PR DESCRIPTION
## Summary
- add `DELETE /voices/{voice_id}` for flat uploaded XTTS samples
- protect multi-sample voice directories from deletion
- atomically replace same-name uploads and invalidate latent cache entries
- expose deletion metadata through `speakers_list_extended`

## Validation
- `python -m unittest tests.test_voice_management`
- syntax-compiled the changed Python files
